### PR TITLE
Refactor GamepadCameraControls to include THREESubset type and implement AbstractGamepadCameraControls interface

### DIFF
--- a/src/camera-controls/GamepadCameraControls.ts
+++ b/src/camera-controls/GamepadCameraControls.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_GAMEPAD_PARAMS,
   DEFAULT_XBOX_GAMEPAD_PARAMS,
 } from "../constants";
+import { type AbstractGamepadCameraControls } from "../core/types";
 
 let _v3A: THREE.Vector3;
 let _v3B: THREE.Vector3;
@@ -17,8 +18,13 @@ let _v3B: THREE.Vector3;
  *
  * @extends CameraControls
  */
-export class GamepadCameraControls extends CameraControls {
+export class GamepadCameraControls
+  extends CameraControls
+  implements AbstractGamepadCameraControls
+{
   private _gamepadIndex: number | null = null;
+
+  private _gamepads: Set<Gamepad>;
 
   private _disposableEvents: Array<Function> = [];
 
@@ -40,15 +46,22 @@ export class GamepadCameraControls extends CameraControls {
     super(camera, domElement);
     this.params = params;
     this.state = DEFAULT_XBOX_GAMEPAD_PARAMS;
+    this._gamepads = new Set<Gamepad>();
 
     const onGamepadConnected = (event: GamepadEvent) => {
       console.log("Gamepad connected:", event.gamepad);
+
       this._gamepadIndex = event.gamepad.index;
+      this._gamepads.add(event.gamepad);
     };
 
-    const onGamepadDisconnect = () => {
+    const onGamepadDisconnect = (event: GamepadEvent) => {
       console.log("Gamepad disconnected");
-      this._gamepadIndex = null;
+
+      this._gamepads.delete(event.gamepad);
+      if (event.gamepad.index === this._gamepadIndex) {
+        this._gamepadIndex = null;
+      }
     };
 
     window.addEventListener("gamepadconnected", onGamepadConnected);
@@ -62,11 +75,14 @@ export class GamepadCameraControls extends CameraControls {
     });
   }
 
-  /**
-   * Checks if a gamepad is connected.
-   *
-   * @returns {boolean} `true` if a gamepad is connected, otherwise `false`.
-   */
+  public getGamepadIndex(): number | null {
+    return this._gamepadIndex;
+  }
+
+  public setGamepadIndex(index: number): void {
+    this._gamepadIndex = index;
+  }
+
   public hasGamepad(): boolean {
     return this._gamepadIndex !== null;
   }

--- a/src/camera-controls/GamepadCameraControls.ts
+++ b/src/camera-controls/GamepadCameraControls.ts
@@ -81,6 +81,10 @@ export class GamepadCameraControls
     });
   }
 
+  public getGamepads(): Readonly<Gamepad[]> {
+    return Array.from(this._gamepads);
+  }
+
   public getGamepadIndex(): number | null {
     return this._gamepadIndex;
   }

--- a/src/camera-controls/GamepadCameraControls.ts
+++ b/src/camera-controls/GamepadCameraControls.ts
@@ -56,7 +56,7 @@ export class GamepadCameraControls
       console.log("Gamepad connected:", event.gamepad);
 
       this._gamepads.add(event.gamepad);
-      if (this._gamepadIndex === null) {
+      if (this._gamepadIndex === null && event.gamepad.mapping === "standard") {
         this._gamepadIndex = event.gamepad.index;
       }
     };

--- a/src/camera-controls/GamepadCameraControls.ts
+++ b/src/camera-controls/GamepadCameraControls.ts
@@ -55,8 +55,10 @@ export class GamepadCameraControls
     const onGamepadConnected = (event: GamepadEvent) => {
       console.log("Gamepad connected:", event.gamepad);
 
-      this._gamepadIndex = event.gamepad.index;
       this._gamepads.add(event.gamepad);
+      if (this._gamepadIndex === null) {
+        this._gamepadIndex = event.gamepad.index;
+      }
     };
 
     const onGamepadDisconnect = (event: GamepadEvent) => {

--- a/src/camera-controls/GamepadCameraControls.ts
+++ b/src/camera-controls/GamepadCameraControls.ts
@@ -26,6 +26,10 @@ export class GamepadCameraControls
 
   private _gamepads: Set<Gamepad>;
 
+  /**
+   * An array to store disposable event handler functions.
+   * These functions can be called to remove event listeners or perform cleanup tasks.
+   */
   private _disposableEvents: Array<Function> = [];
 
   static install(libs: { THREE: THREESubset }): void {
@@ -223,5 +227,13 @@ export class GamepadCameraControls
 
     const to = _v3B.copy(this._targetEnd).add(_v3A);
     return this.moveTo(to.x, to.y, to.z, enableTransition);
+  }
+
+  /**
+   * Dispose the cameraControls instance itself, remove all eventListeners.
+   */
+  public dispose() {
+    super.dispose();
+    this._disposableEvents.forEach((dispose) => dispose());
   }
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -3,7 +3,13 @@
  */
 export type AbstractGamepadCameraControls = {
   /**
-   * Retrieves the index of the connected gamepad.
+   * Retrieves a list of connected gamepads.
+   *
+   * @returns {Readonly<Gamepad[]>} An array of connected gamepads.
+   */
+  getGamepads(): Readonly<Gamepad[]>;
+  /**
+   * Retrieves the index of the active gamepad.
    */
   getGamepadIndex(): number | null;
   /**

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,0 +1,10 @@
+export type AbstractGamepadCameraControls = {
+  getGamepadIndex(): number | null;
+  setGamepadIndex(index: number): void;
+  /**
+   * Checks if a gamepad is connected.
+   *
+   * @returns {boolean} `true` if a gamepad is connected, otherwise `false`.
+   */
+  hasGamepad(): boolean;
+};

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,5 +1,15 @@
+/**
+ * Interface representing the controls for a gamepad camera.
+ */
 export type AbstractGamepadCameraControls = {
+  /**
+   * Retrieves the index of the connected gamepad.
+   */
   getGamepadIndex(): number | null;
+  /**
+   * Sets the index of the gamepad to be used.
+   * @param index
+   */
   setGamepadIndex(index: number): void;
   /**
    * Checks if a gamepad is connected.


### PR DESCRIPTION
Add #15

This pull request refactors the GamepadCameraControls class to include the THREESubset type and implement the AbstractGamepadCameraControls interface. It also adds disposable event handler functions, gamepad index assignment on connection, and a getGamepads method. Additionally, it includes gamepad index assignment on connection based on standard mapping. This refactoring improves the functionality and maintainability of the GamepadCameraControls class.